### PR TITLE
Adding meta/main.yml as it's required for ansible-galaxy based instal…

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,14 +3,11 @@ dependencies: []
 
 galaxy_info:
   author: Jeremy Poulter
-  description: Webgains role for running common linux and AWS tasks.
+  description: Role for setting up agent and registering to AWS Cloudwatch.
   company: "Webgains LTD"
   license: "All rights reserved"
   min_ansible_version: 2.8
   platforms:
-    - name: Centos
-      versions:
-        - all
     - name: Ubuntu
       versions:
         - all

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,10 +2,10 @@
 dependencies: []
 
 galaxy_info:
-  author: Jeremy Poulter
+  author: 1adam
   description: Role for setting up agent and registering to AWS Cloudwatch.
-  company: "Webgains LTD"
-  license: "All rights reserved"
+  company: "globeandmail"
+  license: "MIT"
   min_ansible_version: 2.8
   platforms:
     - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,9 @@ galaxy_info:
   license: "MIT"
   min_ansible_version: 2.8
   platforms:
+    - name: Centos
+      versions:
+        - all
     - name: Ubuntu
       versions:
         - all

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,16 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: Jeremy Poulter
+  description: Webgains role for running common linux and AWS tasks.
+  company: "Webgains LTD"
+  license: "All rights reserved"
+  min_ansible_version: 2.8
+  platforms:
+    - name: Centos
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all


### PR DESCRIPTION
The meta/main.yml file is needed when this role is being installed with ansible-galaxy which is the required method when testing other roles that depend on this file.

Might need to update the values to reflect which OSes this role supports but otherwise is an easy change.

I didn't realise this was a fork so I'm not sure what needs to be changed in the author details and perhaps license. Original was MIT so I guess we're ok to do whatever.