### PR TITLE
Adding task to copy over toml config file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ aws_cwa_disk_monitor_paths:
   - "/"
 
 aws_cwa_cfgs: generic-amazon-cloudwatch-agent.json.j2
+aws_cwa_config: common-config.toml.j2
 aws_cwa_url: "https://s3.amazonaws.com/amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip"
 aws_cwa_local_user: root # The user the CloudWatch Agent runs as.
 aws_cwa_user_path: "/root"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,7 +107,7 @@
     mode: 0644
   notify: restart amazon-cloudwatch-agent
 
-- name: compile and copy over amazon-cloudwatch-agent.json
+- name: compile and copy over common-config.toml
   template:
     src: "{{ aws_cwa_config }}"
     dest: "/opt/aws/amazon-cloudwatch-agent/etc/common-config.toml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,10 +100,17 @@
       state: "absent"
   when: (already_inst is failed) or (aws_install_latest is defined)      
 
-- name: place cfgs, ie. amazon-cloudwatch-agent.json
+- name: compile and copy over amazon-cloudwatch-agent.json
   template:
     src: "{{ aws_cwa_cfgs }}"
     dest: "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
+    mode: 0644
+  notify: restart amazon-cloudwatch-agent
+
+- name: compile and copy over amazon-cloudwatch-agent.json
+  template:
+    src: "{{ aws_cwa_config }}"
+    dest: "/opt/aws/amazon-cloudwatch-agent/etc/common-config.toml"
     mode: 0644
   notify: restart amazon-cloudwatch-agent
 

--- a/templates/common-config.toml.j2
+++ b/templates/common-config.toml.j2
@@ -1,0 +1,24 @@
+# This common-config is used to configure items used for both ssm and cloudwatch access
+
+
+## Configuration for shared credential.
+## Default credential strategy will be used if it is absent here:
+##      Instance role is used for EC2 case by default.
+##      AmazonCloudWatchAgent profile is used for onPremise case by default.
+# [credentials]
+#    shared_credential_profile = "{profile_name}"
+#    shared_credential_file = "{file_name}"
+
+
+## Configuration for proxy.
+## System-wide environment-variable will be read if it is absent here.
+## i.e. HTTP_PROXY/http_proxy; HTTPS_PROXY/https_proxy; NO_PROXY/no_proxy
+## Note: system-wide environment-variable is not accessible when using ssm run-command.
+## Absent in both here and environment-variable means no proxy will be used.
+# [proxy]
+#    http_proxy = "{http_url}"
+#    https_proxy = "{https_url}"
+#    no_proxy = "{domain}"
+
+# [ssl]
+#    ca_bundle_path = "{ca_bundle_file_path}"


### PR DESCRIPTION
Turns out when force upgrading CloudWatch, the cloudwatch dir is deleted and the toml conf file is never recreated. Without this file, CloudWatch Agent fails to start.